### PR TITLE
Potential fix for code scanning alert no. 77: Server-side request forgery

### DIFF
--- a/routes/profileImageUrlUpload.ts
+++ b/routes/profileImageUrlUpload.ts
@@ -16,26 +16,17 @@ import logger from '../lib/logger'
 export function profileImageUrlUpload () {
   return async (req: Request, res: Response, next: NextFunction) => {
     if (req.body.imageUrl !== undefined) {
-      const url = req.body.imageUrl
-      if (url.match(/(.)*solve\/challenges\/server-side(.)*/) !== null) req.app.locals.abused_ssrf_bug = true
-      // SSRF protection: Allow only specific hostnames and protocols
-      let parsedUrl
-      try {
-        parsedUrl = new URL(url)
-      } catch (e) {
-        return res.status(400).send('Malformed URL')
+      // Instead of allowing any user-provided URL, require imageUrl to be an identifier/key
+      const allowedImages: { [key: string]: string } = {
+        'logo': 'https://images.example.com/logo.jpg',
+        'avatar-default': 'https://cdn.example.com/avatar-default.png'
+        // Add further allowed keys/images here
       }
-      // Only allow http and https
-      const allowedProtocols = ['http:', 'https:']
-      const allowedHostnames = [
-        // Add allowed domains below, e.g.:
-        'images.example.com', 'cdn.example.com'
-      ]
-      if (!allowedProtocols.includes(parsedUrl.protocol)) {
-        return res.status(400).send('Protocol not allowed')
-      }
-      if (!allowedHostnames.includes(parsedUrl.hostname)) {
-        return res.status(400).send('Hostname not allowed')
+      const requestedImageKey = req.body.imageUrl;
+      if (requestedImageKey.match(/(.)*solve\/challenges\/server-side(.)*/) !== null) req.app.locals.abused_ssrf_bug = true
+      const url = allowedImages[requestedImageKey]
+      if (!url) {
+        return res.status(400).send('Requested image not allowed')
       }
       const loggedInUser = security.authenticatedUsers.get(req.cookies.token)
       if (loggedInUser) {


### PR DESCRIPTION
Potential fix for [https://github.com/rfreitassouza7/juice-shop-ada-1497/security/code-scanning/77](https://github.com/rfreitassouza7/juice-shop-ada-1497/security/code-scanning/77)

To prevent SSRF vulnerabilities, user input (in this case, `req.body.imageUrl`) should not directly influence the outgoing request URL. Instead, map user input to a fixed set of URLs or hostnames using an allow-list and server-side mapping. For instance, if the client sends a logical identifier such as `"profile1"`, map it to a fixed trusted image URL/server. The most secure approach is to never let a user specify the whole URL or hostname; instead, allow them to pick from a short list (possibly an index or a key), or simply only accept URLs that match exactly those on the allow-list. Thus, update the code so the server matches the user input against a list of known image URLs, or, if that's impractical, against a list of strictly allowed prefixes (full URLs), never letting users provide arbitrary hostnames or complete URLs.

Specifically:  
- Only allow URLs in a strict allow-list for image hosting.  
- If user input is not in the allow-list, reject the request.  
- Edit the SSRF validation and the fetch logic on lines 19-43 so that only mapped URLs can be fetched.  
- All edits should occur in routes/profileImageUrlUpload.ts in the code shown.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
